### PR TITLE
Fixes to the arXiv-cleaning rules

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,7 +1,7 @@
 exports_files([
     "run_latex.py",
     "view_pdf.sh",
-    "get_pdf.sh",
+    "get_file.sh",
     "get_arxivable.sh",
     "pdfcrop.sh",
 ])

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Every `latex_document` rule creates multiple targets:
 * `bazel build [name]` will build the PDF, but it won't be directly accessible.
 * `bazel run [name]_view` will display the PDF in a graphical viewer.
 * `bazel run [name]_getpdf` will copy the PDF into the corresponding directory.
-* `bazel run [name]_arxivable` will create an arXiv-ready version of the
+* `bazel build [name]_arxivable` will create an arXiv-ready version of the
   source using
   [arxiv-latex-cleaner](https://github.com/google-research/arxiv-latex-cleaner),
   but it won't be directly accessible in this directory.

--- a/README.md
+++ b/README.md
@@ -76,14 +76,17 @@ latex_document(
 ```
 
 ### Step 3: Building your Paper
-Every `latex_document` rule creates three targets:
+Every `latex_document` rule creates multiple targets:
 
 * `bazel build [name]` will build the PDF, but it won't be directly accessible.
 * `bazel run [name]_view` will display the PDF in a graphical viewer.
 * `bazel run [name]_getpdf` will copy the PDF into the corresponding directory.
-* `bazel run [name]_getarxivable` will create an arXiv-ready version of the
+* `bazel run [name]_arxivable` will create an arXiv-ready version of the
   source using
-  [arxiv-latex-cleaner](https://github.com/google-research/arxiv-latex-cleaner).
+  [arxiv-latex-cleaner](https://github.com/google-research/arxiv-latex-cleaner),
+  but it won't be directly accessible in this directory.
+* `bazel run [name]_getarxivable` will copy the arXiv-ready version of the
+  source into the current directory.
 
 ## Goals
 These rules are designed to achieve the following goals:

--- a/get_arxivable.sh
+++ b/get_arxivable.sh
@@ -1,7 +1,6 @@
 #!/bin/sh
 
-out_name=$(basename $0).tar.gz
-build_dir=$BUILD_WORKING_DIRECTORY
+out_name=$PWD/./$1
 paper_dir=$(mktemp -d)
 
 cp -LR * $paper_dir
@@ -9,4 +8,4 @@ rm $paper_dir/$(basename $0)
 python3 external/arxiv_latex_cleaner/arxiv_latex_cleaner.py $paper_dir
 
 cd $(echo $paper_dir)_arXiv
-tar -czvf $build_dir/$out_name *
+tar -czvf $out_name *

--- a/get_arxivable.sh
+++ b/get_arxivable.sh
@@ -4,7 +4,7 @@ out_name=$(basename $0).tar.gz
 build_dir=$BUILD_WORKING_DIRECTORY
 paper_dir=$(mktemp -d)
 
-cp -LRr * $paper_dir
+cp -LR * $paper_dir
 rm $paper_dir/$(basename $0)
 python3 external/arxiv_latex_cleaner/arxiv_latex_cleaner.py $paper_dir
 

--- a/get_file.sh
+++ b/get_file.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+builddir=$BUILD_WORKING_DIRECTORY
+cp $1 $builddir/$1
+chmod -x+w $builddir/$1

--- a/get_pdf.sh
+++ b/get_pdf.sh
@@ -1,5 +1,0 @@
-#!/bin/sh
-filename="$(find . -name '*.pdf')"
-builddir=$BUILD_WORKING_DIRECTORY
-cp $filename $builddir/$filename
-chmod -x+w $builddir/$filename

--- a/latex.bzl
+++ b/latex.bzl
@@ -70,7 +70,7 @@ def latex_document(name, main, srcs = []):
 
     # Create an arXiv-ready version of the source.
     native.sh_binary(
-        name = name + "_arxivable",
+        name = name + "_getarxivable",
         srcs = ["@bazel_latex//:get_arxivable.sh"],
         data = srcs + ["@arxiv_latex_cleaner//:all"],
     )

--- a/latex.bzl
+++ b/latex.bzl
@@ -43,6 +43,61 @@ _latex_pdf = rule(
     implementation = _latex_pdf_impl,
 )
 
+def _arxivable_impl(ctx):
+    """Rule to run arxiv-latex-cleaner and produce a .tar.gz of the sources.
+    """
+    texlive_path = ctx.var.get("TEXLIVE_FULL_DIR", None)
+    if texlive_path == None:
+        fail("Please run setup_texlive.sh to set TEXLIVE_FULL_DIR.")
+    ctx.actions.run(
+        mnemonic = "Cleaning",
+        executable = "python",
+        use_default_shell_env = True,
+        arguments = [
+            ctx.files._run_script[0].path,
+            texlive_path,
+            ctx.files._latexrun[0].path,
+            ctx.files.main[0].path.replace(".tex", ""),
+            ctx.files.main[0].path,
+            "--",
+        ] + [src.path for src in ctx.files.srcs] + [
+            "--",
+            ctx.files._arxiv_script[0].path,
+            ctx.outputs.out.path,
+        ],
+        inputs = depset(
+            direct = (ctx.files.main + ctx.files.srcs + ctx.files._latexrun +
+                      ctx.files._run_script + ctx.files._arxiv_script +
+                      ctx.files._arxiv_latex_cleaner),
+        ),
+        outputs = [ctx.outputs.out],
+    )
+
+_arxivable = rule(
+    attrs = {
+        "main": attr.label(allow_files = True),
+        "srcs": attr.label_list(allow_files = True),
+        "_latexrun": attr.label(
+            allow_files = True,
+            default = "@bazel_latex_latexrun//:latexrun",
+        ),
+        "_run_script": attr.label(
+            allow_files = True,
+            default = "@bazel_latex//:run_latex.py",
+        ),
+        "_arxiv_script": attr.label(
+            allow_files = True,
+            default = "@bazel_latex//:get_arxivable.sh",
+        ),
+        "_arxiv_latex_cleaner": attr.label(
+            allow_files = True,
+            default = "@arxiv_latex_cleaner//:all",
+        ),
+    },
+    outputs = {"out": "%{name}.tar.gz"},
+    implementation = _arxivable_impl,
+)
+
 def latex_document(name, main, srcs = []):
     """Given a TeX file, add rules for compiling and archiving it.
     """
@@ -64,13 +119,22 @@ def latex_document(name, main, srcs = []):
     # Copy the PDF into the main working directory.
     native.sh_binary(
         name = name + "_getpdf",
-        srcs = ["@bazel_latex//:get_pdf.sh"],
+        srcs = ["@bazel_latex//:get_file.sh"],
+        args = [name + ".pdf"],
         data = [name + ".pdf"],
     )
 
     # Create an arXiv-ready version of the source.
+    _arxivable(
+        name = name + "_arxivable",
+        srcs = srcs,
+        main = main,
+    )
+
+    # Copy the .tar.gz into the main working directory.
     native.sh_binary(
         name = name + "_getarxivable",
-        srcs = ["@bazel_latex//:get_arxivable.sh"],
-        data = srcs + ["@arxiv_latex_cleaner//:all"],
+        srcs = ["@bazel_latex//:get_file.sh"],
+        args = [name + "_arxivable.tar.gz"],
+        data = [name + "_arxivable.tar.gz"],
     )

--- a/run_latex.py
+++ b/run_latex.py
@@ -1,5 +1,20 @@
 #!/usr/bin/env python
 
+"""Build a LaTeX project.
+
+Two invocations are supported:
+
+1) run_latex.py [texlive] [latexrun] [jobname] [mainfile].tex [outfile].pdf [sources...]
+2) run_latex.py [texlive] [latexrun] [jobname] [mainfile].tex -- [sources...] -- [command...]
+
+The first will build [outfile].pdf from [mainfile].tex and the [sources...].
+This is used to build the PDF file for the [name]_getpdf rules.
+
+The second will build the paper, place [jobname].bbl in the current directory,
+then call [command...]. This is used to build the bbl file for the
+[name]_getarxivable rules.
+"""
+
 import glob
 import os
 import shutil

--- a/run_latex.py
+++ b/run_latex.py
@@ -8,6 +8,9 @@ import sys
 
 texlive, latexrun, job_name, main_file, output_file = sys.argv[1:6]
 sources = sys.argv[6:]
+if output_file == "--":
+    run_after = sources[sources.index("--"):][1:]
+    sources = sources[:sources.index("--")]
 
 env = dict(os.environ)
 # Generated files (eg. outputs of pdfcrop) are placed under bazel-out/*/bin.
@@ -40,4 +43,13 @@ return_code = subprocess.call(
 
 if return_code != 0:
     sys.exit(return_code)
-os.rename(job_name + ".pdf", output_file)
+
+if output_file != "--":
+    os.rename(job_name + ".pdf", output_file)
+else:
+    # Run the run_after script.
+    os.rename("latex.out/" + job_name + ".bbl", job_name + ".bbl")
+    return_code = subprocess.call(
+        args=run_after,
+        env=env,
+    )


### PR DESCRIPTION
This PR adds a number of fixes to the arXiv cleaner rules in order to address #3.

Now, before calling arXiv-latex-cleaner, we actually build the paper inside the sandbox. This ensures that the compiled `.bbl` file is available, as well as any other compiled sources needed (e.g., cropped figures). To do this, I modified `run_latex.py` to optionally take a parameter that specifies a command to run after compilation. Then, for the `_arxivable` rule, I tell it to run the `get_arxivable.sh` script after compiling.

I also simplified the process of getting a PDF/.tar.gz from the sandbox into the build directory.

I will push a few more commits today documenting some of these changes.

From a user perspective, though, nothing really changes except that the arXiv-latex-cleaner should actually work more reliably.