### PR TITLE
Support entries without authors without failing

### DIFF
--- a/dblpify.py
+++ b/dblpify.py
@@ -28,8 +28,8 @@ def main(bib_file):
 
         if results.empty or result is None:
             out_file.write("\n% COULD NOT FIND " + entry["ID"]
-                           + ": " + entry["title"]
-                           + " by " + entry["author"] + "} \n")
+                           + ": " + entry.get("title", "[None]")
+                           + " by " + entry.get("author", "[None]") + "} \n")
             continue
 
         bibtex_url = f"https://dblp.uni-trier.de/rec/{result.Id}.bib?param=1"


### PR DESCRIPTION
Sometimes BibTeX entries don't have authors (or should, but don't _yet_). This caused the old DBLP-ify script to fail. Now it just indicates there is no author.