### PR TITLE
Allow the user to specify which LaTeX compiler to use

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,9 @@ latex_document(
     main = "main.tex",
 )
 ```
+By default, the `latex_document` rule will compiler the PDF with the `pdflatex`
+program. You can instruct it to use another compiler, such as `xelatex`, by
+passing the optional `compiler` option.
 
 ### Step 3: Building your Paper
 Every `latex_document` rule creates multiple targets:

--- a/latex.bzl
+++ b/latex.bzl
@@ -15,6 +15,7 @@ def _latex_pdf_impl(ctx):
             ctx.files._run_script[0].path,
             texlive_path,
             ctx.files._latexrun[0].path,
+            ctx.attr.compiler,
             ctx.label.name,
             ctx.files.main[0].path,
             ctx.outputs.out.path,
@@ -30,6 +31,7 @@ _latex_pdf = rule(
     attrs = {
         "main": attr.label(allow_files = True),
         "srcs": attr.label_list(allow_files = True),
+        "compiler": attr.string(default = "pdflatex"),
         "_latexrun": attr.label(
             allow_files = True,
             default = "@bazel_latex_latexrun//:latexrun",
@@ -98,7 +100,7 @@ _arxivable = rule(
     implementation = _arxivable_impl,
 )
 
-def latex_document(name, main, srcs = []):
+def latex_document(name, main, srcs = [], compiler = "pdflatex"):
     """Given a TeX file, add rules for compiling and archiving it.
     """
 
@@ -107,6 +109,7 @@ def latex_document(name, main, srcs = []):
         name = name,
         srcs = srcs,
         main = main,
+        compiler = compiler,
     )
 
     # Convenience rule for viewing PDFs.

--- a/run_latex.py
+++ b/run_latex.py
@@ -21,7 +21,7 @@ import shutil
 import subprocess
 import sys
 
-texlive, latexrun, job_name, main_file, output_file = sys.argv[1:6]
+texlive, latexrun, compiler, job_name, main_file, output_file = sys.argv[1:7]
 sources = sys.argv[6:]
 if output_file == "--":
     run_after = sources[sources.index("--"):][1:]
@@ -48,7 +48,7 @@ return_code = subprocess.call(
         "python3",
         latexrun,
         "--latex-args=-jobname=" + job_name,
-        "--latex-cmd=pdflatex",
+        "--latex-cmd=" + compiler,
         "--bibtex-cmd=bibtex",
         "-Wall",
         main_file,


### PR DESCRIPTION
We were using `pdflatex` as a default LaTeX compiler. This PR allows the user to specify any of the ones shipped with TeXLive.

This is particularly important because some applications require, e.g., Times New Roman font. In PDFLatex, it looks like it's basically impossible to guarantee this. In XeLaTeX and LuaLaTeX it seems to be possible. So having the option to switch between them can be useful.