### PR TITLE
Use PDFCROP from TeXLive

### DIFF
--- a/pdfcrop.bzl
+++ b/pdfcrop.bzl
@@ -9,14 +9,12 @@ def _pdf_crop_impl(ctx):
         use_default_shell_env = True,
         arguments = [
             ctx.files._pdf_crop_wrapper[0].path,
-            ctx.files._pdf_crop_script[0].path,
             texlive_path,
             uncropped.path,
             ctx.outputs.output.path,
         ],
         inputs = depset(
-            direct = (ctx.files._pdf_crop_script + ctx.files._pdf_crop_wrapper +
-                      [uncropped]),
+            direct = (ctx.files._pdf_crop_wrapper + [uncropped]),
         ),
         outputs = [ctx.outputs.output],
     )
@@ -30,10 +28,6 @@ _pdf_crop = rule(
         "_pdf_crop_wrapper": attr.label(
             allow_files = True,
             default = "@bazel_latex//:pdfcrop.sh",
-        ),
-        "_pdf_crop_script": attr.label(
-            allow_files = True,
-            default = "@pdfcrop//:pdfcrop.pl",
         ),
     },
     implementation = _pdf_crop_impl,

--- a/pdfcrop.sh
+++ b/pdfcrop.sh
@@ -1,14 +1,12 @@
 #!/bin/bash
 
-pdfcrop=$1
-texlive=$2
+texlive=$1
 if [[ $texlive =~ ^[^/].*$ ]]; then
     texlive=$PWD/$texlive
 fi
 echo "Using TeXLive installation: $texlive"
-uncropped=$3
-output=$4
+uncropped=$2
+output=$3
 
 PATH=$texlive/bin/x86_64:$PATH
-PDFCROP=$PWD/$pdfcrop
-$PDFCROP $uncropped $output --pdftex
+pdfcrop $uncropped $output --pdftex

--- a/repositories.bzl
+++ b/repositories.bzl
@@ -19,14 +19,6 @@ def latex_repositories():
     )
 
     http_archive(
-        name = "pdfcrop",
-        build_file_content = "exports_files([\"pdfcrop.pl\"])",
-        sha256 = "4226acd990b3a6db6f9e3bf8949e308b97fa74f8c404023bfb3ce598400a72a4",
-        strip_prefix = "pdfcrop",
-        url = "http://mirrors.ctan.org/support/pdfcrop.zip",
-    )
-
-    http_archive(
         name = "arxiv_latex_cleaner",
         build_file_content = """filegroup(name = "all", srcs = glob(["**"]), visibility = ["//visibility:public"])""",
         sha256 = "770c65993c964405bb5362ee75039970434ef395872356980e470b6b044ac427",


### PR DESCRIPTION
We previously had it download a separate copy of the pdfcrop script from CTAN, which is problematic because we check checksums and CTAN doesn't guarantee a particular version. This just uses the pdfcrop script that TeXLive-full already comes with.